### PR TITLE
Fix ffmpeg loading path

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,12 @@
     import { createFFmpeg, fetchFile } from
       'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.9/dist/ffmpeg.min.js';
 
+    // ---------- ffmpeg core URLs ----------
+    const coreVer  = '0.12.10';          // keep ffmpeg/core in sync with ffmpeg/ffmpeg
+    const coreBase = `https://cdn.jsdelivr.net/npm/@ffmpeg/core@${coreVer}/dist`;
+    const coreJS   = `${coreBase}/ffmpeg-core.js`;
+    const coreWASM = `${coreBase}/ffmpeg-core.wasm`;
+
     /* ---------- WaveSurfer setup ---------- */
     const wavesurfer = WaveSurfer.create({
       container: '#wave',
@@ -69,7 +75,11 @@
       const region = Object.values(wavesurfer.regions.list)[0];
       if (!region) return alert('Draw a selection first');
 
-      const ffmpeg = createFFmpeg({ log: false });
+      const ffmpeg = createFFmpeg({
+        log: false,
+        corePath: coreJS,
+        wasmPath: coreWASM,
+      });
       await ffmpeg.load();
 
       const inputName  = 'input';


### PR DESCRIPTION
## Summary
- add explicit core JS/WASM URLs when creating ffmpeg

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bcae570bc832dbe5f7d815ade70f9