### PR TITLE
Fix ffmpeg CDN path

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     import RegionsPlugin from
       'https://cdn.jsdelivr.net/npm/wavesurfer.js@7.9.8/dist/plugins/regions.esm.js';
     import { createFFmpeg, fetchFile } from
-      'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.15/dist/ffmpeg.min.js';
+      'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.15/+esm';
 
     // ---------- ffmpeg core URLs ----------
     const coreVer  = '0.12.15';          // keep ffmpeg/core in sync with ffmpeg/ffmpeg


### PR DESCRIPTION
## Summary
- use the `/+esm` CDN path for ffmpeg to avoid 404 errors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686bd01fb7bc832d871e09afce35de5d